### PR TITLE
Fix build issues and add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ tests
 tmp*
 *bin/
 !ready-to-run/bin/
+.cache/clangd/index
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -83,11 +83,6 @@ $(BUILD_DIR)/S$(NAME): $(VERI_CSRCS)
 	python3 scripts/sigFilter.py
 	make -s OPT_FAST="-O3" -j -C ./obj_dir -f V$(NAME).mk V$(NAME)
 
-./obj_dir/V$(NAME): $(VERI_CSRCS)
-	verilator $(VERI_VFLAGS) -Wno-lint -j 8 --cc $(VERI_VSRCS) -CFLAGS "$(VERI_CFLAGS)" -LDFLAGS "$(VERI_LDFLAGS)" $^
-	python3 scripts/sigFilter.py
-	make -s OPT_FAST="-O3" -j -C ./obj_dir -f V$(NAME).mk V$(NAME)
-
 difftest: $(target)
 	$(target) $(mainargs)
 

--- a/include/common.h
+++ b/include/common.h
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <stdlib.h>
 #include <cstring>
+#include <cstdint>
 #include <string.h>
 
 #include "debug.h"


### PR DESCRIPTION
- When building with g++13, the compiler reported a problem with missing cstdint header file. To fix this issue, I added the cstdint header file and added necessary compile flags in the build script.
- I found some duplicate build targets in the build script, which could increase build time and waste resources. To fix this issue, I modified the build script to remove the duplicated targets.
- I added some new files and added them to the .gitignore file, which will prevent these files from being accidentally added to the repository.