### PR TITLE
fix: Suppress `-Wunused-but-set-variable` compiler warning

### DIFF
--- a/parser/syntax.y
+++ b/parser/syntax.y
@@ -80,7 +80,7 @@ int p_stoi(const char* str);
 
 %%
 /* remove version */
-circuit: version Circuit ALLID ':' annotations info INDENT cir_mods DEDENT { $$ = newNode(P_CIRCUIT, synlineno(), $6, $3, $8); root = $$; }
+circuit: version Circuit ALLID ':' annotations info INDENT cir_mods DEDENT { $$ = newNode(P_CIRCUIT, synlineno(), $6, $3, $8); root = $$; (void)yynerrs_;}
 	;
 ALLID: ID {$$ = $1; }
     | Inst { $$ = strdup("inst"); }


### PR DESCRIPTION
Bison emits "yynerrs" as a local variable that falls foul of this warning.  To silence those, I inserted "(void) yynerrs;" in the top-level.


```bash
parser/build/syntax.cc:452:9: error: variable 'yynerrs_' set but not used [-Werror,-Wunused-but-set-variable]
  452 |     int yynerrs_ = 0;
      |         ^
1 error generated.
```