### PR TITLE
Fix: use fflush after printf

### DIFF
--- a/src/instsGenerator.cpp
+++ b/src/instsGenerator.cpp
@@ -1443,7 +1443,7 @@ valInfo* ENode::instsPrintf() {
   for (int i = 1; i < getChildNum(); i ++) {
     printfInst += ", " + ChildInfo(i, valStr);
   }
-  printfInst += ");";
+  printfInst += "); fflush(stdout);";
 
   if (ChildInfo(0, status) != VAL_CONSTANT || mpz_cmp_ui(ChildInfo(0, consVal), 0) != 0) {
     ret->insts.push_back(printfInst);


### PR DESCRIPTION
When redirecting guest output to pipe or file, without flush, we may not get any output from the emulator, causing some scripts that require watching the emu output to get nothing.