### PR TITLE
AST2Graph: Override prefix nodes in prev assignTree

### DIFF
--- a/src/AST2Graph.cpp
+++ b/src/AST2Graph.cpp
@@ -1044,7 +1044,11 @@ void visitConnect(graph* g, PNode* connect) {
         if (beg < 0) TODO();
         for (int i = beg; i <= end; i ++) node->invalidIdx.insert(i);
       }
-    } else node->valTree = valTree;
+    } else {
+      // Override all prefix nodes in the prev assignTree.
+      node->assignTree.clear();
+      node->valTree = valTree;
+    }
   }
 }
 


### PR DESCRIPTION
This PR aims to fix the issue of overriding assignments in FIRRTL.

In the following code, the unconditional assignment `assignTree[1]` should override `assignTree[0]`.

```Bash
node soc$axi2sb$io$$out$$req$$valid[width 1 sign 0 status NODE_INVALID type NODE_OTHERS]:
[assign] 0
  (0 (null) 0x555ec02a95f0) soc$axi2sb$io$$out$$req$$valid  [width=-1, sign=0, type=NODE_OTHERS]
  (38 when 0x555ec02a96f0)   [width=-1, sign=0, type=NODE_INVALID]
    (0 (null) 0x555ec02a9770) soc$axi2sb$WHEN_COND_22902  [width=-1, sign=0, type=NODE_OTHERS]
    (42 int 0x555ec02a9670)  1 [width=1, sign=0, type=NODE_INVALID]
    (38 when 0x555ec0296360)   [width=-1, sign=0, type=NODE_INVALID]
      (0 (null) 0x555ec02963e0) soc$axi2sb$WHEN_COND_22857  [width=-1, sign=0, type=NODE_OTHERS]
      (42 int 0x555ec02962e0)  1 [width=1, sign=0, type=NODE_INVALID]
      (EMPTY)
[assign] 1
  (0 (null) 0x555ec02af900) soc$axi2sb$io$$out$$req$$valid  [width=-1, sign=0, type=NODE_OTHERS]
  (0 (null) 0x555ec02af9d0) soc$axi2sb$_io_out_req_valid_T_6  [width=-1, sign=0, type=NODE_OTHERS]
```