### PR TITLE
uint: Fix missing conversion to `uint256_t`

### DIFF
--- a/emu-src/uint.h
+++ b/emu-src/uint.h
@@ -630,6 +630,9 @@ public:
   operator uint128_t () {
     return (uint128_t)u512_0.u256_0;
   }
+  operator uint256_t() {
+    return (uint256_t)u512_0.u256_0;
+  }
   operator uint512_t() {
     return u512_0;
   }


### PR DESCRIPTION
This PR fixes the missing **uint256_t** conversion in **uint1024_t**. Without **uint256_t**, ambiguous conversions may occur, leading the compiler to choose between **uint64_t** and **uint128_t**