### PR TITLE
refactor: remove redundant shift 0 in generated code

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -2,6 +2,12 @@
 #define UTIL_H
 
 #include <sys/time.h>
+#include <string>
+
+enum class ShiftDir{
+  Left,
+  Right,
+};
 
 OPType str2op_expr2(std::string name);
 OPType str2op_expr1(std::string name);
@@ -14,6 +20,8 @@ std::string to_hex_string(BASIC_TYPE x);
 std::pair<int, std::string> firStrBase(std::string s);
 std::string format(const char *fmt, ...);
 std::string bitMask(int width);
+std::string shiftBits(unsigned int bits, ShiftDir dir);
+std::string shiftBits(std::string bits, ShiftDir dir);
 void print_stacktrace();
 
 static inline struct timeval getTime() {

--- a/src/cppEmitter.cpp
+++ b/src/cppEmitter.cpp
@@ -3,6 +3,7 @@
 */
 
 #include "common.h"
+#include "util.h"
 
 #include <cstddef>
 #include <cstdio>
@@ -118,7 +119,7 @@ std::string updateActiveStr(int idx, uint64_t mask, std::string& cond, int uniqu
   auto activeFlags = std::string("activeFlags[") + std::to_string(idx) + std::string("]");
 
   if (mask <= MAX_U8) {
-    if (uniqueId >= 0) return format("%s |= %s << %d;", activeFlags.c_str(), cond.c_str(), uniqueId);
+    if (uniqueId >= 0) return format("%s |= %s %s;", activeFlags.c_str(), cond.c_str(), shiftBits(uniqueId, ShiftDir::Left).c_str());
     else return format("%s |= -(uint8_t)%s & 0x%lx;", activeFlags.c_str(), cond.c_str(), mask, activeFlags.c_str());
   }
   if (mask <= MAX_U16)
@@ -222,9 +223,10 @@ FILE* graph::genHeaderStart() {
     for (int i = num; i > 0; i --) param += format(i == num ? "_%d" : ", _%d", i);
     std::string value;
     std::string type = widthUType(num * 64);
-    for (int i = num; i > 0; i --) {
+    for (int i = num; i > 1; i --) {
       value += format(i == num ? "((%s)_%d << %d) " : "| ((%s)_%d << %d)", type.c_str(), i, (i-1) * 64);
     }
+    value += format("| ((%s)_1)", type.c_str());
     fprintf(header, "#define UINT_CONCAT%d(%s) (%s)\n", num, param.c_str(), value.c_str());
   }
   for (std::string str : extDecl) fprintf(header, "%s\n", str.c_str());
@@ -569,10 +571,11 @@ void graph::nodeDisplay(Node* member) {
       s += "|%%lx"; \
     } \
     s += "\", "; \
-    for (n --; n >= 0; n --) { \
+    for (n --; n > 0; n --) { \
       s += format("(uint64_t)(%s >> %d)", varname, n * 64); \
-      if (n != 0) s += ", "; \
+      s += ", "; \
     } \
+    s += format("(uint64_t)%s",varname);\
     s += ");"; \
     emitBodyLock(s.c_str()); \
   } while (0)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include "common.h"
 #include <execinfo.h>
+#include "util.h"
 
 /* convert firrtl constant to C++ constant 
    In the new FIRRTL spec, there are 'int' and 'rint'.*/
@@ -130,6 +131,17 @@ std::string bitMask(int width) {
       return format("(((%s)1 << %d) - 1)", type.c_str(), width);
     }
   }
+}
+
+std::string shiftBits(unsigned int bits, ShiftDir dir){
+  if(bits == 0)
+    return "";
+  return (dir == ShiftDir::Left? " << " : " >> ") + std::to_string(bits);
+}
+std::string shiftBits(std:: string bits, ShiftDir dir){
+  if(bits == std::to_string(0) || bits == "0x0")
+    return "";
+  return (dir == ShiftDir::Left? " << " : " >> ") + bits;
 }
 
 void print_stacktrace() {


### PR DESCRIPTION
Tested with make diff dutName={rocket|small-boom|large-boom}

I also want to recommend bumping to C++ 20 so we can use std::format instead. Which can help us get rid of those ugly `c_str()`.
Or, since most format strings is now simplified to sth like "(%s(%s%s %s) %s)", we can also use `+` instead of format.
