### PR TITLE
perf: Introduce bolt to build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ CFLAGS_DUT = -DDUT_NAME=S$(NAME) -DDUT_HEADER=\"$(NAME).h\" -D__DUT_$(shell echo
 
 # $(1): object file
 # $(2): source file
-# $(3): compile flags
+# $(3): compile flags (for linker flags, use -Xlinker --xxx instead of -Wl,--xxx)
 # $(4): object file list
 # $(5): extra dependency
 define CXX_TEMPLATE =
@@ -70,7 +70,7 @@ endef
 
 # $(1): object file
 # $(2): source file
-# $(3): ld flags
+# $(3): ld flags (use -Xlinker --xxx instead of -Wl,--xxx)
 define LD_TEMPLATE =
 $(1): $(2)
 	@mkdir -p $$(@D) && echo + LD $$@
@@ -84,7 +84,8 @@ ifeq ($(PERF),1)
 	target ?= run-emu
 else ifeq ($(MODE),0)
 	MODE_FLAGS += -DGSIM
-	EMU_CFLAGS += -O3 -Wno-format $(PGO_CFLAGS)
+	EMU_CFLAGS += -O3 -Wno-format $(PGO_CFLAGS) $(BOLT_CFLAGS)
+	EMU_LDFLAGS += $(BOLT_LDFLAGS)
 	target ?= run-emu
 else ifeq ($(MODE), 1)
 	MODE_FLAGS += -DVERILATOR
@@ -195,7 +196,9 @@ EMU_CFLAGS += -fbracket-depth=2048
 $(foreach x, $(EMU_SRCS), $(eval \
 	$(call CXX_TEMPLATE, $(EMU_BUILD_DIR)/$(basename $(notdir $(x))).o, $(x), $(EMU_CFLAGS), EMU_OBJS,)))
 
-$(eval $(call LD_TEMPLATE, $(EMU_BIN), $(EMU_OBJS), $(EMU_CFLAGS)))
+$(eval $(call LD_TEMPLATE, $(EMU_BIN), $(EMU_OBJS), $(EMU_CFLAGS) $(EMU_LDFLAGS)))
+
+build-emu: $(EMU_BIN)
 
 run-emu: $(EMU_BIN)
 	$(TIME) taskset 0x1 $^ $(mainargs)
@@ -206,7 +209,7 @@ clean-emu:
 # Dependency
 -include $(EMU_OBJS:.o=.d)
 
-.PHONY: run-emu clean-emu
+.PHONY: run-emu clean-emu build-emu
 
 ##############################################
 ### Building EMU from Verilator
@@ -284,6 +287,39 @@ pgo:
 	$(MAKE) run MODE=0 PGO_CFLAGS="-fprofile-use=$(PGO_BUILD_DIR)/default.profdata"
 
 .PHONY: pgo
+
+##############################################
+### BOLT
+##############################################
+
+BOLT_BUILD_DIR = $(WORK_DIR)/bolt
+BOLT_INSTRUMENT ?= $(shell perf record -e cycles -j any,u -- ls >/dev/null 2>&1; echo $$?)
+
+bolt:
+	mkdir -p $(BOLT_BUILD_DIR)
+	$(MAKE) compile MODE=0
+	$(MAKE) clean-emu
+	$(MAKE) build-emu MODE=0 BOLT_CFLAGS="-DPERF_CYCLE" BOLT_LDFLAGS="-Xlinker --emit-relocs"
+ifeq ($(BOLT_INSTRUMENT), 0)
+	perf record -e cycles:u -j any,u -o $(BOLT_BUILD_DIR)/perf.data -- $(EMU_BIN) $(mainargs)
+	perf2bolt -p $(BOLT_BUILD_DIR)/perf.data -o $(BOLT_BUILD_DIR)/perf.fdata $(EMU_BIN)
+else
+	llvm-bolt $(EMU_BIN) -instrument -o $(BOLT_BUILD_DIR)/S$(NAME).inst --instrumentation-file=$(BOLT_BUILD_DIR)/perf.fdata
+	$(BOLT_BUILD_DIR)/S$(NAME).inst $(mainargs)
+endif
+	$(MAKE) clean-emu 
+	$(MAKE) build-emu MODE=0 BOLT_LDFLAGS="-Xlinker --emit-relocs"
+	llvm-bolt $(EMU_BIN) -o $(EMU_BIN).bolt \
+			-data=$(BOLT_BUILD_DIR)/perf.fdata \
+			-reorder-blocks=ext-tsp \
+			-reorder-functions=cdsort \
+			-split-functions \
+			-split-all-cold \
+			-split-eh
+	@mv $(EMU_BIN).bolt $(EMU_BIN)
+	$(MAKE) run MODE=0
+
+.PHONY: bolt
 
 ##############################################
 ### Miscellaneous

--- a/emu/emu.cpp
+++ b/emu/emu.cpp
@@ -27,12 +27,12 @@
 #elif defined(__DUT_rocket__)
 #define DUT_MEMORY mem$srams$mem
 #define REF_MEMORY TestHarness__DOT__mem__DOT__srams__DOT__mem_ext__DOT__Memory
-#define CYCLE_MAX_PERF 3000000
+#define CYCLE_MAX_PERF 2000000
 #define CYCLE_MAX_SIM  4200000
 #elif defined(__DUT_large_boom__) || defined(__DUT_small_boom__)
 #define DUT_MEMORY mem$srams$mem
 #define REF_MEMORY TestHarness__DOT__mem__DOT__srams__DOT__mem_ext__DOT__Memory
-#define CYCLE_MAX_PERF 5000000
+#define CYCLE_MAX_PERF 1000000
 #ifdef __DUT_large_boom__
 #define CYCLE_MAX_SIM  3900000
 #else
@@ -302,8 +302,9 @@ int main(int argc, char** argv) {
         out << dut->allNames[sorted[i]] << " " << dut->nodeNum[sorted[i]] << " " << (double)activeTimes[sorted[i]] / cycles << " " << activeTimes[sorted[i]] << " " \
             << dut->posActives[sorted[i]] << " "  << (double)dut->posActives[sorted[i]] / activeTimes[sorted[i]] << std::endl;
       }
-
-      if (cycles == CYCLE_MAX_PERF) return 0;
+#endif
+#if defined(PERF) || defined(PERF_CYCLE)
+      if (cycles >= CYCLE_MAX_PERF) return 0;
 #endif
       if (cycles == CYCLE_MAX_SIM) return 0;
     }

--- a/scripts/regression.sh
+++ b/scripts/regression.sh
@@ -1,10 +1,12 @@
+#!/bin/bash
+
 # usage: regression.sh
-# See log file at build/$task/$task.log
+# See log file at build/$task/$task.log and build/regression.log
 
 TASKS="ysyx3 rocket small-boom large-boom minimal-xiangshan default-xiangshan"
 
 function log() {
-  echo "`date`|| $1"
+  echo "`date`|| $1" | tee -a build/regression.log
 }
 
 function rebuild_gsim() {
@@ -35,6 +37,8 @@ for t in $TASKS; do
   result=`grep "simulation process 100.00%" build/$t/$t.log | grep -o "[0-9]* per sec" | awk '{print $1}'`
   make pgo dutName=$t -j `nproc` > /dev/null
   result_pgo=`grep "simulation process 100.00%" build/$t/$t.log | grep -o "[0-9]* per sec" | awk '{print $1}'`
-  log "$t(non-pgo / pgo): ${result}Hz / ${result_pgo}Hz"
+  make bolt dutName=$t -j `nproc` > /dev/null
+  result_bolt=`grep "simulation process 100.00%" build/$t/$t.log | grep -o "[0-9]* per sec" | awk '{print $1}'`
+  log "$t(plain / pgo / bolt ): ${result}Hz / ${result_pgo}Hz / ${result_bolt}Hz"
 done
 log "Performance regression finish"

--- a/src/inferWidth.cpp
+++ b/src/inferWidth.cpp
@@ -9,6 +9,13 @@
 #define s1 getChild(1)->sign
 #define s2 getChild(2)->sign
 
+/*
+ * Recursively calculates the width of each ENode (DFS)
+ * For leaf ENodes, the width is directly derived from the corresponding Node.
+ * For non-leaf ENodes, the width is determined based on:
+ *     1. The widths of its child ENodes, and
+ *     2. The operation represented by this ENode.
+ */
 void ENode::inferWidth() {
   for (ENode* enode : child) {
     if (enode) enode->inferWidth();


### PR DESCRIPTION
[BOLT](https://github.com/llvm/llvm-project/tree/main/bolt) is a post-link optimizer developed to speed up large applications. It achieves this by optimizing the code layout based on execution profiles.
### Test result

 | DUT                 | plain (Hz) | pgo (Hz)   | bolt (Hz)  |
|----------------------|--------------|------------|------------|
| ysyx3               | 1598837      | 1629388    | 1792406    |
| rocket              | 435368       | 449342     | 495984     |
| small-boom          | 91196        | 114725     | 126448     |
| large-boom          | 27833        | 48473      | 53465      |
| minimal-xiangshan   | 8558         | 12788      | 13665      |
| default-xiangshan   | 4044         | 6812       | 7292       |

BOLT mainly reduces cache misses by reordering blocks. 
For example, on my device:
* Plain LargeBoom: 150 L1i misses per 1k instructions
* BOLT LargeBoom: 108 L1i misses per 1k instructions
 ( PGO and BOLT+PGO is similar to this, and BOLT+PGO speed is almost identical to only BOLT)

BOLT is also faster to run, it takes 43s to process default-XiangShan on my device. (PGO require to recompile every file)
Binary file is larger due to `emit-relocs` in link stage, and bolt will duplicate the section before making any modification. 


Note that gsim shows no improvement with BOLT, likely due to its already low L1i$ miss rate. 

Also, most DUT and gsim exhibit performance degradation when LTO (full or thin) is enabled, for unknown reason.