### PR TITLE
Flip and Deduplicate SUPER_INFO_ASSIGN_{BEG/END} in both branches of OP_STMT_WHEN and Place it outside the SUPER_INFO_IF block

### DIFF
--- a/include/Node.h
+++ b/include/Node.h
@@ -357,10 +357,11 @@ enum SuperType {
 enum SuperInfo {
   SUPER_INFO_IF,     // start indent
   SUPER_INFO_ELSE,   // dedent and then indent
+  SUPER_INFO_INDENT,
   SUPER_INFO_DEDENT,
   SUPER_INFO_STR,
-  SUPER_INFO_ASSIGN_BEG,
-  SUPER_INFO_ASSIGN_END
+  SUPER_INFO_ASSIGN_BEG, // backup the value
+  SUPER_INFO_ASSIGN_END  // compare the backuped value
 };
 
 class InstInfo{
@@ -380,6 +381,11 @@ public:
     node = _node;
     inst = _inst;
     infoType = _infoType;
+  }
+  bool operator<(const InstInfo& other) const {
+    if (infoType != other.infoType) return infoType < other.infoType;
+    if (inst != other.inst) return inst < other.inst;
+    return node < other.node;
   }
 };
 class SuperNode {

--- a/include/StmtTree.h
+++ b/include/StmtTree.h
@@ -27,7 +27,7 @@ public:
   void eraseChild(size_t idx) { child.erase(child.begin() + checkChildIdx(idx)); }
   void addChild(StmtNode* node) { child.push_back(node); }
   void generateWhenTree(ENode* lvalue, ENode* enode, std::vector<int>& subPath, Node* belong);
-  void compute(std::vector<InstInfo>& insts);
+  void compute(std::vector<InstInfo>& insts, std::set<InstInfo> assign_insts[] = nullptr);
 };
 
 class StmtTree {

--- a/src/cppEmitter.cpp
+++ b/src/cppEmitter.cpp
@@ -386,14 +386,15 @@ void graph::genNodeDef(FILE* fp, Node* node) {
     if (node->dimension.empty()) {
       emitBodyLock(1, "%s &= %s;\n", node->name.c_str(), bitMask(w).c_str());
     } else {
+      int indent = 1;
       int dims = node->dimension.size();
       for (int i = 0; i < dims; i ++) {
-        emitBodyLock(1, "for (int i%d = 0; i%d < %d; i%d ++) {\n", i, i, node->dimension[i], i);
+        emitBodyLock(indent++, "for (int i%d = 0; i%d < %d; i%d ++) {\n", i, i, node->dimension[i], i);
       }
-      emitBodyLock(1, "%s", node->name.c_str());
+      emitBodyLock(indent, "%s", node->name.c_str());
       for (int i = 0; i < dims; i ++) { emitBodyLock(0, "[i%d]", i); }
       emitBodyLock(0, "&= %s;\n", bitMask(w).c_str());
-      for (int i = 0; i < dims; i ++) { emitBodyLock(0, "}\n"); }
+      for (int i = 0; i < dims; i ++) { emitBodyLock(-- indent, "}\n"); }
     }
   }
 
@@ -755,6 +756,10 @@ void graph::genSuperEval(SuperNode* super, std::string flagName, int indent) { /
         case SUPER_INFO_ELSE:
           emitBodyLock(indent - 1,  "%s\n", inst.inst.c_str());
           break;
+        case SUPER_INFO_INDENT:
+          emitBodyLock(indent, "%s\n", inst.inst.c_str());
+          indent ++;
+          break;
         case SUPER_INFO_DEDENT:
           indent --;
           emitBodyLock(indent, "%s\n", inst.inst.c_str());
@@ -853,11 +858,12 @@ void graph::genResetDef(SuperNode* super, bool isUIntReset, int indent) {
       emitBodyLock(indent, "%s // %s\n", updateActiveStr(iter.first, ACTIVE_MASK(iter.second)).c_str(), ACTIVE_COMMENT(iter.second).c_str());
     }
   }
-  emitBodyLock(indent, "}\n");
+  emitBodyLock(-- indent, "}\n");
   for (InstInfo inst : super->insts) {
     switch (inst.infoType) {
       case SUPER_INFO_IF:
       case SUPER_INFO_ELSE:
+      case SUPER_INFO_INDENT:
       case SUPER_INFO_DEDENT:
       case SUPER_INFO_STR:
         emitBodyLock(indent, "%s\n", inst.inst.c_str());

--- a/src/instsGenerator.cpp
+++ b/src/instsGenerator.cpp
@@ -183,11 +183,11 @@ static std::string arrayCopy(std::string lvalue, Node* node, valInfo* rinfo, int
   } else {
     std::string idxStr, bracket;
     for (size_t i = 0; i < node->dimension.size() - dimIdx; i ++) {
-      ret += format("for(int i%ld = 0; i%ld < %d; i%ld ++) {\n", i, i, node->dimension[i + dimIdx], i);
+      ret += format("for(int i%ld = 0; i%ld < %d; i%ld ++) { ", i, i, node->dimension[i + dimIdx], i);
       idxStr += "[i" + std::to_string(i) + "]";
-      bracket += "}\n";
+      bracket += "}";
     }
-    ret += format("%s%s = %s;\n", lvalue.c_str(), idxStr.c_str(), rinfo->valStr.c_str());
+    ret += format("%s%s = %s; ", lvalue.c_str(), idxStr.c_str(), rinfo->valStr.c_str());
     ret += bracket;
   }
   return ret;
@@ -1939,21 +1939,51 @@ valInfo* Node::compute() {
   return ret;
 }
 
-void StmtNode::compute(std::vector<InstInfo>& insts) {
+void StmtNode::compute(std::vector<InstInfo>& insts, std::set<InstInfo> assign_insts[]) {
   switch (type) {
     case OP_STMT_SEQ:
       for (StmtNode* stmt : child) {
-        stmt->compute(insts);
+        stmt->compute(insts, assign_insts);
       }
       break;
     case OP_STMT_WHEN: {
       Assert(getChild(0)->isENode, "invalid when condition\n");
+      std::set<InstInfo> insts_branch_assign[2]; // Collector for all the SUPER_INFO_ASSIGN_{BEG/END}
       valInfo* cond = getChild(0)->enode->compute(nullptr, INVALID_LVALUE, false);
-      insts.push_back(InstInfo(format("if %s {", addBracket(cond->valStr).c_str()), SUPER_INFO_IF));
-      getChild(1)->compute(insts);
-      insts.push_back(InstInfo("} else {", SUPER_INFO_ELSE));
-      getChild(2)->compute(insts);
-      insts.push_back(InstInfo("}", SUPER_INFO_DEDENT));
+      insts.emplace_back(format("if %s {", addBracket(cond->valStr).c_str()), SUPER_INFO_IF);
+      auto if_marker = insts.size() - 1;
+      getChild(1)->compute(insts,insts_branch_assign);
+      /* Don't emit empty else block */
+      if (!getChild(2)->child.empty()) {
+        insts.emplace_back("} else {", SUPER_INFO_ELSE);
+        getChild(2)->compute(insts, insts_branch_assign);
+      }
+      insts.emplace_back("}", SUPER_INFO_DEDENT); // if block
+/*
+ * Deduplicate SUPER_INFO_ASSIGN_{BEG/END} in both branches of OP_STMT_WHEN and Place it outside the SUPER_INFO_IF block
+ * From:                            | To:
+ *   SUPER_INFO_IF                  | {
+ *     SUPER_INFO_ASSIGN_BEG A      |   SUPER_INFO_ASSIGN_BEG A
+ *     xxx = yyy                    |   SUPER_INFO_ASSIGN_BEG B
+ *     SUPER_INFO_ASSIGN_END A      |   SUPER_INFO_IF
+ *   SUPER_INFO_ELSE                |      xxx = yyy
+ *     SUPER_INFO_ASSIGN_BEG A      |   SUPER_INFO_ELSE
+ *     SUPER_INFO_ASSIGN_BEG B      |      xxx = zzz
+ *     xxx = zzz                    |      iii = jjj
+ *     iii = jjj                    |   SUPER_INFO_DEDENT
+ *     SUPER_INFO_ASSIGN_END A      |   SUPER_INFO_ASSIGN_END A
+ *     SUPER_INFO_ASSIGN_END B      |   SUPER_INFO_ASSIGN_END B
+ *   SUPER_INFO_DEDENT              | }
+ */
+      if (!insts_branch_assign[1].empty()) {
+        insts.insert(insts.begin() + static_cast<std::ptrdiff_t>(if_marker), std::make_move_iterator(insts_branch_assign[0].begin()), std::make_move_iterator(insts_branch_assign[0].end()));
+        insts.insert(insts.end(), std::make_move_iterator(insts_branch_assign[1].begin()), std::make_move_iterator(insts_branch_assign[1].end()));
+        /* avoid {\n{ */
+        if (if_marker != 0 && insts.at(if_marker - 1).infoType != SUPER_INFO_IF && insts.at(if_marker - 1).infoType != SUPER_INFO_ELSE) {
+          insts.insert(insts.begin() + static_cast<std::ptrdiff_t>(if_marker), InstInfo("{", SUPER_INFO_INDENT));
+          insts.emplace_back("}", SUPER_INFO_DEDENT);
+        }
+      }
       break;
     }
     case OP_STMT_NODE: {
@@ -1962,22 +1992,34 @@ void StmtNode::compute(std::vector<InstInfo>& insts) {
       valInfo* linfo = tree->getlval()->compute(node, INVALID_LVALUE, false);
       valInfo* rinfo = tree->getRoot()->compute(node, linfo->valStr, true);
       if (rinfo->status == VAL_FINISH || node->type == NODE_SPECIAL) { // printf / assert
-        insts.push_back(InstInfo(rinfo->valStr));
+        insts.emplace_back(rinfo->valStr);
       } else if (rinfo->status == VAL_INVALID) {
       } else if (rinfo->opNum >= 0) {
         if (rinfo->valStr != linfo->valStr) {
-          if (belong) insts.push_back(InstInfo(SUPER_INFO_ASSIGN_BEG, belong));
-          if (isSubArray(linfo->valStr, node)) {
-            insts.push_back(InstInfo(arrayCopy(linfo->valStr, node, rinfo)));
-          } else {
-            insts.push_back(InstInfo(format("%s = %s;", linfo->valStr.c_str(), rinfo->valStr.c_str())));
+          if (belong){
+            if (assign_insts) assign_insts[0].emplace(SUPER_INFO_ASSIGN_BEG, belong);
+            else insts.emplace_back(SUPER_INFO_ASSIGN_BEG, belong);
           }
-          if (belong) insts.push_back(InstInfo(SUPER_INFO_ASSIGN_END, belong));
+          if (isSubArray(linfo->valStr, node)) {
+            insts.emplace_back(arrayCopy(linfo->valStr, node, rinfo));
+          } else {
+            insts.emplace_back(format("%s = %s;", linfo->valStr.c_str(), rinfo->valStr.c_str()));
+          }
+          if (belong) {
+            if (assign_insts) assign_insts[1].emplace(SUPER_INFO_ASSIGN_END, belong);
+            else insts.emplace_back(SUPER_INFO_ASSIGN_END, belong);
+          }
         }
       } else {
-        if (belong) insts.push_back(InstInfo(SUPER_INFO_ASSIGN_BEG, belong));
-        insts.push_back(InstInfo(rinfo->valStr));
-        if (belong) insts.push_back(InstInfo(SUPER_INFO_ASSIGN_END, belong));
+        if (belong) {
+          if (assign_insts) assign_insts[0].emplace(SUPER_INFO_ASSIGN_BEG, belong);
+          else insts.emplace_back(SUPER_INFO_ASSIGN_BEG, belong);
+        }
+        insts.emplace_back(rinfo->valStr);
+        if (belong) {
+          if (assign_insts) assign_insts[1].emplace(SUPER_INFO_ASSIGN_END, belong);
+          else insts.emplace_back(SUPER_INFO_ASSIGN_END, belong);
+        }
       }
       break;
     }


### PR DESCRIPTION
Refactoring: Deduplicating SUPER_INFO_ASSIGN_{BEG/END}

| From | To |
|------|----|
| SUPER_INFO_IF<br>  SUPER_INFO_ASSIGN_BEG A<br>  xxx = yyy<br>  SUPER_INFO_ASSIGN_END A<br>SUPER_INFO_ELSE<br>  SUPER_INFO_ASSIGN_BEG A<br>  SUPER_INFO_ASSIGN_BEG B<br>  xxx = zzz<br>  iii = jjj<br>  SUPER_INFO_ASSIGN_END A<br>  SUPER_INFO_ASSIGN_END B<br>SUPER_INFO_DEDENT | {<br>  SUPER_INFO_ASSIGN_BEG A<br>  SUPER_INFO_ASSIGN_BEG B<br>  SUPER_INFO_IF<br>     xxx = yyy<br>  SUPER_INFO_ELSE<br>     xxx = zzz<br>     iii = jjj<br>  SUPER_INFO_DEDENT<br>  SUPER_INFO_ASSIGN_END A<br>  SUPER_INFO_ASSIGN_END B<br>} |

Example
![image](https://github.com/user-attachments/assets/f63c64b0-e4e7-419e-9290-fea8d62570e4)
In this example, SUPER_INFO_ASSIGN_{BEG/END} is moved from point B to point C
![image](https://github.com/user-attachments/assets/fec992cb-a8ac-4f6e-928c-a2cc2d40268c)


To avoid redeclaration, a scope is added when necessary.
![image](https://github.com/user-attachments/assets/fd725197-b76c-4f7b-b1d7-de10afc1fded)


This pr also fix some minor indent issue. This pr also remove empty else block like ` else {  }`in the example
