### PR TITLE
Begin adding CIRCT support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,4 @@ data/
 doc/html
 *.out
 *.data*
-*.txt
 emu/obj*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.15)
+project(gsim LANGUAGES CXX)
+
+# ---------- 1. 找工具 ----------
+find_package(FLEX REQUIRED)
+find_package(BISON REQUIRED)
+
+find_library(GMP_LIB gmp REQUIRED)
+find_package(Threads REQUIRED)
+
+# ---------- 2. 生成文件 ----------
+# 让 bison 先跑，产出 parser.cpp + parser.h
+bison_target(
+  GsimParser
+  ${CMAKE_CURRENT_SOURCE_DIR}/parser/syntax.y
+  ${CMAKE_CURRENT_BINARY_DIR}/parser/syntax.cpp
+  COMPILE_FLAGS "-v -d --defines=${CMAKE_CURRENT_BINARY_DIR}/parser/syntax.hh"   # 生成头文件
+)
+
+# 让 flex 跑，产出 lexer.cpp；依赖上面的 parser.h
+flex_target(
+  GsimLexer
+  ${CMAKE_CURRENT_SOURCE_DIR}/parser/lexical.l
+  ${CMAKE_CURRENT_BINARY_DIR}/parser/lexical.cpp
+  COMPILE_FLAGS "-Cf"
+)
+
+# 把两个 target 绑定到同一个名字，后面直接引用
+add_flex_bison_dependency(GsimLexer GsimParser)
+
+file(GLOB_RECURSE SRC_FILES CONFIGURE_DEPENDS
+     src/*.cpp parser/*.cpp)   # 现有源文件
+
+add_executable(${PROJECT_NAME}
+  ${SRC_FILES}
+  ${BISON_GsimParser_OUTPUTS}
+  ${FLEX_GsimLexer_OUTPUTS}
+)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC ${GMP_LIB} Threads::Threads)
+
+target_include_directories(${PROJECT_NAME} PRIVATE
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/parser/include  
+  ${CMAKE_CURRENT_BINARY_DIR}/parser
+)
+
+set_property(TARGET ${PROJECT_NAME} PROPERTY CXX_STANDARD 17)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,29 @@ find_package(BISON REQUIRED)
 find_library(GMP_LIB gmp REQUIRED)
 find_package(Threads REQUIRED)
 
+set(LLVM_DIR "/download/llvm_mlir_circt/circt/install/llvm/lib/cmake/llvm" CACHE PATH "" FORCE)
+set(MLIR_DIR "/download/llvm_mlir_circt/circt/install/llvm/lib/cmake/mlir" CACHE PATH "" FORCE)
+set(CIRCT_DIR "/download/llvm_mlir_circt/circt/install/circt/lib/cmake/circt" CACHE PATH "" FORCE)
+find_package(LLVM REQUIRED CONFIG)
+find_package(MLIR REQUIRED CONFIG)
+find_package(CIRCT REQUIRED CONFIG)
+
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+message(STATUS "Found MLIR ${MLIR_PACKAGE_VERSION}")
+message(STATUS "Using MLIRConfig.cmake in: ${MLIR_DIR}")
+message(STATUS "Found CIRCT ${CIRCT_PACKAGE_VERSION}")
+message(STATUS "Using CIRCTConfig.cmake in: ${CIRCT_DIR}")
+
+list(APPEND CMAKE_MODULE_PATH "${MLIR_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${CIRCT_DIR}")
+list(APPEND CMAKE_MODULE_PATH "${LLVM_DIR}")
+include(AddLLVM)
+include(AddMLIR)
+include(AddCIRCT)
+include_directories(${LLVM_INCLUDE_DIRS})
+include_directories(${MLIR_INCLUDE_DIRS})
+include_directories(${CIRCT_INCLUDE_DIRS})
 # ---------- 2. 生成文件 ----------
 # 让 bison 先跑，产出 parser.cpp + parser.h
 bison_target(
@@ -37,7 +60,12 @@ add_executable(${PROJECT_NAME}
   ${FLEX_GsimLexer_OUTPUTS}
 )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC ${GMP_LIB} Threads::Threads)
+set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fexceptions -fno-rtti")
+
+target_link_libraries(${PROJECT_NAME} PRIVATE ${GMP_LIB} Threads::Threads)
+target_link_libraries(${PROJECT_NAME} PRIVATE MLIRIR MLIRParser MLIRPass MLIRSupport 
+                                              CIRCTHW CIRCTComb CIRCTSV CIRCTSeq CIRCTEmit CIRCTOM
+                                              LLVMSupport LLVMCore)
 
 target_include_directories(${PROJECT_NAME} PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-fexceptions -fn
 target_link_libraries(${PROJECT_NAME} PRIVATE ${GMP_LIB} Threads::Threads)
 target_link_libraries(${PROJECT_NAME} PRIVATE MLIRIR MLIRParser MLIRPass MLIRSupport 
                                               CIRCTHW CIRCTComb CIRCTSV CIRCTSeq CIRCTEmit CIRCTOM
-                                              LLVMSupport LLVMCore)
+                                              LLVMSupport)
 
 target_include_directories(${PROJECT_NAME} PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/include

--- a/Makefile
+++ b/Makefile
@@ -125,59 +125,11 @@ difftest: $(target)$(SIMPOINT_VAR)
 ### Building GSIM
 ##############################################
 
-GSIM_BUILD_DIR = $(BUILD_DIR)/gsim
-GSIM_BIN = $(GSIM_BUILD_DIR)/gsim
-
-PARSER_DIR = parser
-LEXICAL_NAME = lexical
-SYNTAX_NAME = syntax
-PARSER_BUILD_DIR = $(GSIM_BUILD_DIR)/$(PARSER_DIR)
-PARSER_GEN_SRCS = $(foreach x, $(LEXICAL_NAME) $(SYNTAX_NAME), $(PARSER_BUILD_DIR)/$(x).cc)
-PARSER_GEN_HEADER = $(PARSER_BUILD_DIR)/$(SYNTAX_NAME).hh
-GSIM_SRCS = $(foreach x, src $(PARSER_DIR), $(wildcard $(x)/*.cpp))
-
-GSIM_INC_DIR = include $(PARSER_DIR)/include $(PARSER_BUILD_DIR)
-# NOTE:
-# 1) pthread symbols (pthread_create / pthread_join) were missing at link stage;
-#    with clang this is solved by adding -pthread to both compile & link flags.
-# 2) If you still see "DWARF error: invalid or unhandled FORM value: 0x25" from ld
-#    your binutils (ld) may be older than the DWARF version emitted by clang-19.
-#    You can force DWARF v4 by building with: make DWARF4=1 ... (see conditional below).
-CXXFLAGS += -ggdb -O3 -MMD $(addprefix -I,$(GSIM_INC_DIR)) -Wall -Werror --std=c++17 -pthread
-
-ifeq ($(DWARF4),1)
-	CXXFLAGS += -gdwarf-4
-endif
-
-ifeq ($(DEBUG),1)
-	CXXFLAGS += -DDEBUG
-endif
-
-# Optional: build static binary (enable with `make STATIC=1 build-gsim`)
-ifeq ($(STATIC),1)
-# Link libstdc++ and libgcc statically; attempt full static if available
-LDFLAGS += -static -static-libstdc++ -static-libgcc
-endif
-
-$(PARSER_BUILD_DIR)/%.cc:  $(PARSER_DIR)/%.y
-	@mkdir -p $(@D)
-	bison -v -d $< -o $@
-
-$(PARSER_BUILD_DIR)/%.cc: $(PARSER_DIR)/%.l
-	@mkdir -p $(@D)
-	flex -Cf -o $@ $<
-
-$(PARSER_GEN_HEADER): $(PARSER_BUILD_DIR)/$(SYNTAX_NAME).cc
-
-$(foreach x, $(PARSER_GEN_SRCS), $(eval \
-	$(call CXX_TEMPLATE, $(PARSER_BUILD_DIR)/$(basename $(notdir $(x))).o, $(x), $(CXXFLAGS), GSIM_OBJS, $(PARSER_GEN_HEADER))))
-
-$(foreach x, $(GSIM_SRCS), $(eval \
-	$(call CXX_TEMPLATE, $(GSIM_BUILD_DIR)/$(basename $(x)).o, $(x), $(CXXFLAGS), GSIM_OBJS, $(PARSER_GEN_HEADER))))
-
-$(eval $(call LD_TEMPLATE, $(GSIM_BIN), $(GSIM_OBJS), $(CXXFLAGS) -lgmp))
+GSIM_BIN = $(BUILD_DIR)/gsim
 
 build-gsim: $(GSIM_BIN)
+	@echo "Please build gsim with CMAKE first."
+
 
 # Dependency
 -include $(GSIM_OBJS:.o=.d)

--- a/include/CIRCT2Graph.h
+++ b/include/CIRCT2Graph.h
@@ -1,0 +1,39 @@
+/*
+  Generate design graph (the intermediate representation of the input circuit) from AST
+*/
+#ifndef CIRCT2GRAPH_H
+#define CIRCT2GRAPH_H
+#include "common.h"
+#include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Emit/EmitDialect.h"
+#include "circt/Dialect/Emit/EmitOps.h"
+#include "circt/Dialect/OM/OMDialect.h"
+#include "circt/Dialect/OM/OMOps.h"
+#include "mlir/IR/BuiltinOps.h"
+#include <map>
+using namespace mlir;
+using namespace circt;
+
+class CIRCT2Graph {
+ public:
+  CIRCT2Graph(ModuleOp module) {
+    module->walk([&](hw::HWModuleOp hwModuleOp) { topModule = hwModuleOp; });
+  }
+  graph* generateGraph();
+ private:
+  graph* g;
+  hw::HWModuleOp topModule;
+  std::unordered_map<mlir::Value, Node*> valueNodeMap;
+
+  void processInputPort();
+  void processOperations();
+};
+
+#endif

--- a/src/CIRCT2Graph.cpp
+++ b/src/CIRCT2Graph.cpp
@@ -1,0 +1,38 @@
+/*
+  Generate design graph (the intermediate representation of the input circuit) from AST
+*/
+#include "CIRCT2Graph.h"
+
+graph* CIRCT2Graph::generateGraph() {
+  g = new graph();
+  processInputPort();
+  return g;
+}
+
+void CIRCT2Graph::processInputPort() {
+  size_t inputPortIdx = 0;
+  for(size_t i = 0; i < topModule.getNumPorts(); i++) {
+    auto portInfo = topModule.getPort(i);
+    if(portInfo.isOutput()) continue;
+    // 创建 typeInfo
+    TypeInfo* typeInfo = new TypeInfo();
+    typeInfo->set_sign(portInfo.type.isSignedInteger());
+    typeInfo->set_width(portInfo.type.getIntOrFloatBitWidth());
+    typeInfo->set_reset(UNCERTAIN);
+    // 创建 node
+    Node* node = new Node(NODE_INP); 
+    node->name = topModule.getPortName(i).str();
+    node->updateInfo(typeInfo);
+    // 将 node 添加到图中
+    g->input.push_back(node);
+    // 将 value-node 关系添加到 map 中
+    mlir::Value portValue = topModule.getBodyRegion().front().getArgument(inputPortIdx);
+    valueNodeMap[portValue] = node;
+    inputPortIdx++;
+  }
+}
+
+void CIRCT2Graph::processOperations() {
+
+}
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,6 +13,41 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include "circt/Dialect/SV/SVDialect.h"
+#include "circt/Dialect/SV/SVOps.h"
+#include "circt/Dialect/HW/HWDialect.h"
+#include "circt/Dialect/HW/HWOps.h"
+#include "circt/Dialect/Comb/CombDialect.h"
+#include "circt/Dialect/Comb/CombOps.h"
+#include "circt/Dialect/Seq/SeqDialect.h"
+#include "circt/Dialect/Seq/SeqOps.h"
+#include "circt/Dialect/Emit/EmitDialect.h"
+#include "circt/Dialect/Emit/EmitOps.h"
+#include "circt/Dialect/OM/OMDialect.h"
+#include "circt/Dialect/OM/OMOps.h"
+#include "mlir/IR/AsmState.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Parser/Parser.h"
+#include "llvm/Support/CommandLine.h"
+#include "llvm/Support/ErrorOr.h"
+#include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/raw_ostream.h"
+
+
+using namespace mlir;
+using namespace circt::hw;
+using namespace circt::sv;
+using namespace circt::comb;
+using namespace circt::seq;
+using namespace circt::emit;
+using namespace circt::om;
+
+
+static llvm::cl::opt<std::string>
+    inputFile(llvm::cl::Positional, llvm::cl::Required,
+              llvm::cl::desc("<input .mlir file>"));
 
 PNode* parseFIR(char *strbuf);
 void preorder_traversal(PNode* root);
@@ -131,6 +166,45 @@ static char* readFile(const char *InputFileName, size_t &size, size_t &mapSize) 
  * @return exit state.
  */
 int main(int argc, char** argv) {
+
+  llvm::cl::ParseCommandLineOptions(argc, argv, "CIRCT HW walk example\n");
+
+  // 1. 创建 MLIR 上下文并注册 HW 方言
+  MLIRContext context;
+  context.loadDialect<HWDialect>();
+  context.loadDialect<SVDialect>();
+  context.loadDialect<CombDialect>();
+  context.loadDialect<SeqDialect>();
+  context.loadDialect<EmitDialect>();
+  context.loadDialect<OMDialect>();
+
+  // 2. 把文件读进 SourceMgr
+  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> fileOrErr =
+      llvm::MemoryBuffer::getFile(inputFile);
+  if (std::error_code ec = fileOrErr.getError()) {
+    llvm::errs() << "Cannot open '" << inputFile << "': " << ec.message() << "\n";
+    return 1;
+  }
+  llvm::SourceMgr sourceMgr;
+  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
+
+  // 3. 解析成 ModuleOp
+  OwningOpRef<ModuleOp> module = parseSourceFile<ModuleOp>(sourceMgr, &context);
+  if (!module) {
+    llvm::errs() << "Error parsing " << inputFile << "\n";
+    return 1;
+  }
+
+  // 4. 遍历模块内所有操作（含嵌套）
+  module->walk([&](Operation *op) {
+    // 只打印 HW 方言的操作，可按需要过滤
+    if (isa<HWDialect>(op->getDialect()))
+      llvm::outs() << "HW op: " << op->getName() << " at "
+                   << op->getLoc() << "\n";
+  });
+
+  return 0;
+
   TIMER_START(total);
   graph* g = NULL;
   static int dumpIdx = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 
 #include "common.h"
 #include "graph.h"
+#include "CIRCT2Graph.h"
 
 #include <getopt.h>
 #include <sys/mman.h>
@@ -35,7 +36,6 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 
-
 using namespace mlir;
 using namespace circt::hw;
 using namespace circt::sv;
@@ -44,12 +44,7 @@ using namespace circt::seq;
 using namespace circt::emit;
 using namespace circt::om;
 
-
-static llvm::cl::opt<std::string>
-    inputFile(llvm::cl::Positional, llvm::cl::Required,
-              llvm::cl::desc("<input .mlir file>"));
-
-PNode* parseFIR(char *strbuf);
+PNode* parseFIR(char* strbuf);
 void preorder_traversal(PNode* root);
 graph* AST2Graph(PNode* root);
 void inferAllWidth();
@@ -66,17 +61,16 @@ Config::Config() {
 }
 Config globalConfig;
 
+#define FUNC_WRAPPER_INTERNAL(func, name, dumpCond)                                          \
+  do {                                                                                       \
+    struct timeval start = getTime();                                                        \
+    func;                                                                                    \
+    struct timeval end = getTime();                                                          \
+    showTime("{" #func "}", start, end);                                                     \
+    if (dumpCond && globalConfig.EnableDumpGraph) g->dump(std::to_string(dumpIdx++) + name); \
+  } while (0)
 
-#define FUNC_WRAPPER_INTERNAL(func, name, dumpCond) \
-  do { \
-    struct timeval start = getTime(); \
-    func; \
-    struct timeval end = getTime(); \
-    showTime("{" #func "}", start, end); \
-    if (dumpCond && globalConfig.EnableDumpGraph) g->dump(std::to_string(dumpIdx ++) + name); \
-  } while(0)
-
-#define FUNC_TIMER(func)         FUNC_WRAPPER_INTERNAL(func, "", false)
+#define FUNC_TIMER(func) FUNC_WRAPPER_INTERNAL(func, "", false)
 #define FUNC_WRAPPER(func, name) FUNC_WRAPPER_INTERNAL(func, name, true)
 
 static void printUsage(const char* ProgName) {
@@ -88,8 +82,7 @@ static void printUsage(const char* ProgName) {
             << "      --supernode-max-size=[num]   Specify the maximum size of a superNode.\n"
             << "      --cpp-max-size-KB=[num]      Specify the maximum size (approximate) of a generated C++ file.\n"
             << "      --sep-mod=[str]              Specify the seperator for submodule (default: $).\n"
-            << "      --sep-aggr=[str]             Specify the seperator for aggregate member (default: $$).\n"
-            ;
+            << "      --sep-aggr=[str]             Specify the seperator for aggregate member (default: $$).\n";
 }
 
 static char* parseCommandLine(int argc, char** argv) {
@@ -97,7 +90,7 @@ static char* parseCommandLine(int argc, char** argv) {
     printUsage(argv[0]);
     std::cout.flush();
     fflush(nullptr);
-    _exit(EXIT_SUCCESS); // avoid running atexit/destructors which crash in full-static
+    _exit(EXIT_SUCCESS);  // avoid running atexit/destructors which crash in full-static
   }
 
   const struct option Table[] = {
@@ -117,20 +110,25 @@ static char* parseCommandLine(int argc, char** argv) {
   int option_index;
   while ((Option = getopt_long(argc, argv, "-h", Table, &option_index)) != -1) {
     switch (Option) {
-      case 0: switch (option_index) {
-                case 1: globalConfig.EnableDumpGraph = true; break;
-                case 2: globalConfig.OutputDir = optarg; break;
-                case 3: sscanf(optarg, "%d", &globalConfig.SuperNodeMaxSize); break;
-                case 4: sscanf(optarg, "%d", &globalConfig.cppMaxSizeKB); break;
-                case 5: globalConfig.sep_module = optarg; break;
-                case 6: globalConfig.sep_aggr = optarg; break;
-                case 7: sscanf(optarg, "%d", &globalConfig.MergeWhenSize); break;
-                case 8: sscanf(optarg, "%d", &globalConfig.When2muxBound); break;
-                case 0:
-                default: printUsage(argv[0]); std::cout.flush(); fflush(nullptr); _exit(EXIT_SUCCESS);
-              }
-              break;
-      case 1: return optarg; // InputFileName
+      case 0:
+        switch (option_index) {
+          case 1: globalConfig.EnableDumpGraph = true; break;
+          case 2: globalConfig.OutputDir = optarg; break;
+          case 3: sscanf(optarg, "%d", &globalConfig.SuperNodeMaxSize); break;
+          case 4: sscanf(optarg, "%d", &globalConfig.cppMaxSizeKB); break;
+          case 5: globalConfig.sep_module = optarg; break;
+          case 6: globalConfig.sep_aggr = optarg; break;
+          case 7: sscanf(optarg, "%d", &globalConfig.MergeWhenSize); break;
+          case 8: sscanf(optarg, "%d", &globalConfig.When2muxBound); break;
+          case 0:
+          default:
+            printUsage(argv[0]);
+            std::cout.flush();
+            fflush(nullptr);
+            _exit(EXIT_SUCCESS);
+        }
+        break;
+      case 1: return optarg;  // InputFileName
       case 'd': globalConfig.EnableDumpGraph = true; break;
       default: {
         printUsage(argv[0]);
@@ -143,7 +141,7 @@ static char* parseCommandLine(int argc, char** argv) {
   assert(0);
 }
 
-static char* readFile(const char *InputFileName, size_t &size, size_t &mapSize) {
+static char* readFile(const char* InputFileName, size_t& size, size_t& mapSize) {
   int fd = open(InputFileName, O_RDONLY);
   assert(fd != -1);
   struct stat sb;
@@ -151,8 +149,8 @@ static char* readFile(const char *InputFileName, size_t &size, size_t &mapSize) 
   assert(ret != -1);
   size = sb.st_size + 1;
   mapSize = (size + 4095) & ~4095L;
-  char *buf = (char *)mmap(NULL, mapSize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
-  assert(buf != (void *)-1);
+  char* buf = (char*)mmap(NULL, mapSize, PROT_READ | PROT_WRITE, MAP_PRIVATE, fd, 0);
+  assert(buf != (void*)-1);
   buf[size - 1] = '\0';
   close(fd);
   return buf;
@@ -167,58 +165,62 @@ static char* readFile(const char *InputFileName, size_t &size, size_t &mapSize) 
  */
 int main(int argc, char** argv) {
 
-  llvm::cl::ParseCommandLineOptions(argc, argv, "CIRCT HW walk example\n");
-
-  // 1. 创建 MLIR 上下文并注册 HW 方言
-  MLIRContext context;
-  context.loadDialect<HWDialect>();
-  context.loadDialect<SVDialect>();
-  context.loadDialect<CombDialect>();
-  context.loadDialect<SeqDialect>();
-  context.loadDialect<EmitDialect>();
-  context.loadDialect<OMDialect>();
-
-  // 2. 把文件读进 SourceMgr
-  llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> fileOrErr =
-      llvm::MemoryBuffer::getFile(inputFile);
-  if (std::error_code ec = fileOrErr.getError()) {
-    llvm::errs() << "Cannot open '" << inputFile << "': " << ec.message() << "\n";
-    return 1;
-  }
-  llvm::SourceMgr sourceMgr;
-  sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
-
-  // 3. 解析成 ModuleOp
-  OwningOpRef<ModuleOp> module = parseSourceFile<ModuleOp>(sourceMgr, &context);
-  if (!module) {
-    llvm::errs() << "Error parsing " << inputFile << "\n";
-    return 1;
-  }
-
-  // 4. 遍历模块内所有操作（含嵌套）
-  module->walk([&](Operation *op) {
-    // 只打印 HW 方言的操作，可按需要过滤
-    if (isa<HWDialect>(op->getDialect()))
-      llvm::outs() << "HW op: " << op->getName() << " at "
-                   << op->getLoc() << "\n";
-  });
-
-  return 0;
-
   TIMER_START(total);
   graph* g = NULL;
   static int dumpIdx = 0;
-  const char *InputFileName = parseCommandLine(argc, argv);
+  const char* InputFileName = parseCommandLine(argc, argv);
 
-  size_t size = 0, mapSize = 0;
-  char *strbuf;
-  FUNC_TIMER(strbuf = readFile(InputFileName, size, mapSize));
+  // 判断文件名结尾是 fir 还是 mlir
+  assert(InputFileName != NULL);
+  const char* suffix = strrchr(InputFileName, '.');
+  assert(suffix != NULL);
+  bool isFir = false;
+  if (strcmp(suffix, ".fir") == 0) {
+    // 解析 fir 文件
+    size_t size = 0, mapSize = 0;
+    char* strbuf;
+    FUNC_TIMER(strbuf = readFile(InputFileName, size, mapSize));
 
-  PNode* globalRoot;
-  FUNC_TIMER(globalRoot= parseFIR(strbuf));
-  munmap(strbuf, mapSize);
+    PNode* globalRoot;
+    FUNC_TIMER(globalRoot = parseFIR(strbuf));
+    munmap(strbuf, mapSize);
 
-  FUNC_WRAPPER(g = AST2Graph(globalRoot), "Init");
+    FUNC_WRAPPER(g = AST2Graph(globalRoot), "Init");
+  } else if (strcmp(suffix, ".mlir") == 0) {
+    // 解析 mlir 文件
+    // 1. 创建 MLIR 上下文并注册 HW 方言
+    MLIRContext context;
+    context.loadDialect<HWDialect>();
+    context.loadDialect<SVDialect>();
+    context.loadDialect<CombDialect>();
+    context.loadDialect<SeqDialect>();
+    context.loadDialect<EmitDialect>();
+    context.loadDialect<OMDialect>();
+
+    // 2. 把文件读进 SourceMgr
+    llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> fileOrErr = llvm::MemoryBuffer::getFile(InputFileName);
+    if (std::error_code ec = fileOrErr.getError()) {
+      llvm::errs() << "Cannot open '" << InputFileName << "': " << ec.message() << "\n";
+      return 1;
+    }
+    llvm::SourceMgr sourceMgr;
+    sourceMgr.AddNewSourceBuffer(std::move(*fileOrErr), SMLoc());
+
+    // 3. 解析成 ModuleOp
+    OwningOpRef<ModuleOp> module = parseSourceFile<ModuleOp>(sourceMgr, &context);
+    if (!module) {
+      llvm::errs() << "Error parsing " << InputFileName << "\n";
+      return 1;
+    }
+
+    CIRCT2Graph circt2Graph(module.get());
+    FUNC_WRAPPER(g = circt2Graph.generateGraph(), "Init_CIRCT");
+  } else {
+    std::cout << "Error: input file should be .fir or .mlir\n";
+    std::cout.flush();
+    fflush(nullptr);
+    _exit(EXIT_FAILURE);
+  }
 
   FUNC_TIMER(g->splitArray());
 


### PR DESCRIPTION
- Migrated gsim's build tooling to CMake for easier integration with LLVM/MLIR/CIRCT
- Added parameters for reading MLIR input and branch paths (see main and CIRCT2Graph)
- Initial attempt made to read NODE_INP, but not yet tested