### PR TITLE
chore: add nix flake for xs-env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ doc/html
 *.txt
 emu/obj*
 playground/
+
+# nix build .
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1771903837,
+        "narHash": "sha256-sdaqdnsQCv3iifzxwB22tUwN/fSHoN7j2myFW5EIkGk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e764fc9a405871f1f6ca3d1394fb422e0a0c3951",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "GSIM: A Fast RTL Simulator for Large-Scale Designs";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+  };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      systems = nixpkgs.lib.systems.flakeExposed;
+      perSystem = nixpkgs.lib.genAttrs systems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          llvm = pkgs.llvmPackages_19;
+          gsim = llvm.stdenv.mkDerivation {
+            pname = "gsim";
+            version = "1.0.0-dev"; # FIXME?
+            src = self;
+
+            strictDeps = true;
+            enableParallelBuilding = true;
+            dontConfigure = true;
+
+            nativeBuildInputs = [
+              pkgs.flex
+              pkgs.bison
+            ];
+            buildInputs = [
+              pkgs.flex
+              pkgs.gmp
+            ];
+
+            makeFlags = [
+              # gsim defaults to /bin/bash, which is not guaranteed in NixOS
+              "SHELL=${llvm.stdenv.shell}"
+              # override default build target to avoid running tests
+              "build-gsim"
+            ];
+
+            installPhase = ''
+              runHook preInstall
+              install -Dm755 build/gsim/gsim $out/bin/gsim
+              runHook postInstall
+            '';
+
+            meta = {
+              description = "Fast RTL Simulator for Large-Scale Designs";
+              homepage = "https://github.com/OpenXiangShan/gsim";
+              platforms = pkgs.lib.platforms.linux;
+            };
+          };
+        in
+        {
+          packages = {
+            gsim = gsim;
+            default = gsim;
+          };
+        }
+      );
+    in
+    {
+      packages = nixpkgs.lib.mapAttrs (_: v: v.packages) perSystem;
+    };
+}


### PR DESCRIPTION
To build gsim dynamically-linked binary: `nix build .` (equivalent to `nix build .#gsim`)

To use in a devShell (recommended): https://github.com/OpenXiangShan/xs-env/pull/72

Use case with direnv:
<img width="1318" height="1638" alt="image" src="https://github.com/user-attachments/assets/fb0808f6-6f33-4836-a7b6-4260612391aa" />
